### PR TITLE
Wireguard implementation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ COPY check-wg0.sh /usr/local/bin/check-wg0.sh
 RUN echo 'nobody ALL=(ALL) NOPASSWD: /usr/sbin/crond' > /etc/sudoers && \
     printenv > /etc/environment && \
     chown -R nobody:nogroup ${TARGET_DIR} /etc/environment && \
-    chmod 755 /usr/local/bin/device-templates.sh && \
+    chmod 755 /usr/local/bin/device-templates.sh /usr/local/bin/init-wireguard.sh /usr/local/bin/check-wg0.sh && \
     echo '0 * * * * /usr/local/bin/device-templates.sh' > /etc/crontabs/root && \
     echo '*/5 * * * * /usr/local/bin/init-wireguard.sh' >> /etc/crontabs/root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,8 @@ COPY init-wireguard.sh /usr/local/bin/init-wireguard.sh
 COPY check-wg0.sh /usr/local/bin/check-wg0.sh
 
 # Install ca-certificates and set timezone to UTC for wget to work properly
-RUN apk add --no-cache ca-certificates tzdata && \
-    cp /usr/share/zoneinfo/UTC /etc/localtime && \
-    echo "UTC" > /etc/timezone
+#TODO: do I need this?
+RUN apk add --no-cache ca-certificates tzdata
 
 # add crond to be used with sudo by nobody user & 
 # add global env vars to be used in cron & 

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,8 +44,7 @@ COPY check-wg0.sh /usr/local/bin/check-wg0.sh
 # add global env vars to be used in cron & 
 # Set permissions &
 # Set up cron job
-# TODO: change back to nobody once tested
-RUN echo 'root ALL=(ALL) NOPASSWD: /usr/sbin/crond' > /etc/sudoers && \
+RUN echo 'nobody ALL=(ALL) NOPASSWD: /usr/sbin/crond' > /etc/sudoers && \
     printenv > /etc/environment && \
     chown -R nobody:nogroup ${TARGET_DIR} /etc/environment && \
     chmod 755 /usr/local/bin/device-templates.sh /usr/local/bin/init-wireguard.sh /usr/local/bin/check-wg0.sh && \
@@ -53,4 +52,4 @@ RUN echo 'root ALL=(ALL) NOPASSWD: /usr/sbin/crond' > /etc/sudoers && \
     echo '*/5 * * * * /usr/local/bin/init-wireguard.sh' >> /etc/crontabs/root
 
 # restore the running as `nobody` as is defined by chirpstack docker image
-# USER nobody:nogroup TODO: comment out once done testing
+USER nobody:nogroup

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,8 @@ COPY check-wg0.sh /usr/local/bin/check-wg0.sh
 # add global env vars to be used in cron & 
 # Set permissions &
 # Set up cron job
-RUN echo 'nobody ALL=(ALL) NOPASSWD: /usr/sbin/crond' > /etc/sudoers && \
+# TODO: change back to nobody once tested
+RUN echo 'root ALL=(ALL) NOPASSWD: /usr/sbin/crond' > /etc/sudoers && \
     printenv > /etc/environment && \
     chown -R nobody:nogroup ${TARGET_DIR} /etc/environment && \
     chmod 755 /usr/local/bin/device-templates.sh /usr/local/bin/init-wireguard.sh /usr/local/bin/check-wg0.sh && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,22 @@
+# --------------------------------------
+# Stage 1: Build wireguard-go binary
+# --------------------------------------
+FROM golang:1.23-alpine AS builder
+
+# Install build dependencies
+RUN apk add --no-cache git make
+
+# Clone and checkout specific wireguard-go tag
+ENV WIREGUARD_GO_VERSION=0.0.20250522
+RUN git clone https://git.zx2c4.com/wireguard-go \
+ && cd wireguard-go \
+ && git checkout ${WIREGUARD_GO_VERSION} \
+ && make \
+ && cp wireguard-go /wireguard-go
+
+# --------------------------------------
+# Stage 2: Final image with ChirpStack
+# --------------------------------------
 # If you migrate to chirpstack=>4.7v, a migration needs to be done
 #check this: https://www.chirpstack.io/docs/chirpstack/changelog.html#v470
 FROM chirpstack/chirpstack:4.6
@@ -7,13 +26,11 @@ ENV TARGET_DIR=/opt/lorawan-devices
 
 USER root
 
-# Install packages
-RUN apk update && apk add --no-cache go git bash sudo wireguard-tools jq make \
- && git clone https://git.zx2c4.com/wireguard-go \
- && cd wireguard-go \
- && make \
- && cp wireguard-go /usr/local/bin/wireguard-go \
- && cd .. && rm -rf wireguard-go
+# Install runtime dependencies
+RUN apk update && apk add --no-cache bash sudo wireguard-tools jq
+
+# Copy built wireguard-go from builder
+COPY --from=builder /wireguard-go /usr/local/bin/wireguard-go
 
 # clone DEVICE_TEMPLATES_REPO 
 RUN git clone ${DEVICE_TEMPLATES_REPO} -b master --single-branch ${TARGET_DIR}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV TARGET_DIR=/opt/lorawan-devices
 USER root
 
 # Install packages
-RUN apk update && apk add --no-cache git bash sudo wireguard-tools curl jq
+RUN apk update && apk add --no-cache git bash sudo wireguard-tools jq
 
 # clone DEVICE_TEMPLATES_REPO 
 RUN git clone ${DEVICE_TEMPLATES_REPO} -b master --single-branch ${TARGET_DIR}

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN git clone https://git.zx2c4.com/wireguard-go \
 # --------------------------------------
 # If you migrate to chirpstack=>4.7v, a migration needs to be done
 #check this: https://www.chirpstack.io/docs/chirpstack/changelog.html#v470
-FROM chirpstack/chirpstack:4.6
+FROM chirpstack/chirpstack:4.14
 
 ENV DEVICE_TEMPLATES_REPO=https://github.com/waggle-sensor/wes-lorawan-device-templates
 ENV TARGET_DIR=/opt/lorawan-devices

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,4 +52,4 @@ RUN echo 'nobody ALL=(ALL) NOPASSWD: /usr/sbin/crond' > /etc/sudoers && \
     echo '*/5 * * * * /usr/local/bin/init-wireguard.sh' >> /etc/crontabs/root
 
 # restore the running as `nobody` as is defined by chirpstack docker image
-USER nobody:nogroup
+# USER nobody:nogroup TODO: comment out once done testing

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,9 @@ ENV TARGET_DIR=/opt/lorawan-devices
 USER root
 
 # Install packages
-RUN apk update && apk add --no-cache git bash sudo wireguard-tools jq
+RUN apk update && apk add --no-cache go git bash sudo wireguard-tools jq \
+ && go install golang.zx2c4.com/wireguard-go@latest \
+ && mv /root/go/bin/wireguard-go /usr/local/bin/wireguard-go
 
 # clone DEVICE_TEMPLATES_REPO 
 RUN git clone ${DEVICE_TEMPLATES_REPO} -b master --single-branch ${TARGET_DIR}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV TARGET_DIR=/opt/lorawan-devices
 USER root
 
 # Install packages
-RUN apk update && apk add --no-cache git bash sudo wireguard-tools curl jq
+RUN apk update && apk add --no-cache git bash sudo wireguard-tools jq
 
 # clone DEVICE_TEMPLATES_REPO 
 RUN git clone ${DEVICE_TEMPLATES_REPO} -b master --single-branch ${TARGET_DIR}
@@ -17,6 +17,11 @@ RUN git clone ${DEVICE_TEMPLATES_REPO} -b master --single-branch ${TARGET_DIR}
 COPY device-templates.sh /usr/local/bin/device-templates.sh
 COPY init-wireguard.sh /usr/local/bin/init-wireguard.sh
 COPY check-wg0.sh /usr/local/bin/check-wg0.sh
+
+# Install ca-certificates and set timezone to UTC for wget to work properly
+RUN apk add --no-cache ca-certificates tzdata && \
+    cp /usr/share/zoneinfo/UTC /etc/localtime && \
+    echo "UTC" > /etc/timezone
 
 # add crond to be used with sudo by nobody user & 
 # add global env vars to be used in cron & 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV TARGET_DIR=/opt/lorawan-devices
 USER root
 
 # Install packages
-RUN apk update && apk add --no-cache go git bash sudo wireguard-tools jq \
+RUN apk update && apk add --no-cache go git bash sudo wireguard-tools jq make \
  && git clone https://git.zx2c4.com/wireguard-go \
  && cd wireguard-go \
  && make \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,6 @@ COPY device-templates.sh /usr/local/bin/device-templates.sh
 COPY init-wireguard.sh /usr/local/bin/init-wireguard.sh
 COPY check-wg0.sh /usr/local/bin/check-wg0.sh
 
-# Install ca-certificates and set timezone to UTC for wget to work properly
-#TODO: do I need this?
-RUN apk add --no-cache ca-certificates tzdata
-
 # add crond to be used with sudo by nobody user & 
 # add global env vars to be used in cron & 
 # Set permissions &

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,15 @@ ENV TARGET_DIR=/opt/lorawan-devices
 USER root
 
 # Install packages
-RUN apk update && apk add --no-cache git bash sudo
+RUN apk update && apk add --no-cache git bash sudo wireguard-tools curl jq
 
 # clone DEVICE_TEMPLATES_REPO 
 RUN git clone ${DEVICE_TEMPLATES_REPO} -b master --single-branch ${TARGET_DIR}
 
-# Copy script into the container
+# Copy scripts into the container
 COPY device-templates.sh /usr/local/bin/device-templates.sh
+COPY init-wireguard.sh /usr/local/bin/init-wireguard.sh
+COPY check-wg0.sh /usr/local/bin/check-wg0.sh
 
 # add crond to be used with sudo by nobody user & 
 # add global env vars to be used in cron & 
@@ -24,7 +26,8 @@ RUN echo 'nobody ALL=(ALL) NOPASSWD: /usr/sbin/crond' > /etc/sudoers && \
     printenv > /etc/environment && \
     chown -R nobody:nogroup ${TARGET_DIR} /etc/environment && \
     chmod 755 /usr/local/bin/device-templates.sh && \
-    echo '0 * * * * /usr/local/bin/device-templates.sh' > /etc/crontabs/root
+    echo '0 * * * * /usr/local/bin/device-templates.sh' > /etc/crontabs/root && \
+    echo '*/5 * * * * /usr/local/bin/init-wireguard.sh' >> /etc/crontabs/root
 
 # restore the running as `nobody` as is defined by chirpstack docker image
 USER nobody:nogroup

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ ENV TARGET_DIR=/opt/lorawan-devices
 USER root
 
 # Install runtime dependencies
-RUN apk update && apk add --no-cache bash sudo wireguard-tools jq
+RUN apk update && apk add --no-cache git bash sudo wireguard-tools jq
 
 # Copy built wireguard-go from builder
 COPY --from=builder /wireguard-go /usr/local/bin/wireguard-go

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV TARGET_DIR=/opt/lorawan-devices
 USER root
 
 # Install packages
-RUN apk update && apk add --no-cache git bash sudo wireguard-tools jq
+RUN apk update && apk add --no-cache git bash sudo wireguard-tools curl jq
 
 # clone DEVICE_TEMPLATES_REPO 
 RUN git clone ${DEVICE_TEMPLATES_REPO} -b master --single-branch ${TARGET_DIR}

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,11 @@ USER root
 
 # Install packages
 RUN apk update && apk add --no-cache go git bash sudo wireguard-tools jq \
- && go install golang.zx2c4.com/wireguard-go@latest \
- && mv /root/go/bin/wireguard-go /usr/local/bin/wireguard-go
+ && git clone https://git.zx2c4.com/wireguard-go \
+ && cd wireguard-go \
+ && make \
+ && cp wireguard-go /usr/local/bin/wireguard-go \
+ && cd .. && rm -rf wireguard-go
 
 # clone DEVICE_TEMPLATES_REPO 
 RUN git clone ${DEVICE_TEMPLATES_REPO} -b master --single-branch ${TARGET_DIR}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,20 @@
 # Waggle Edge Stack Chirpstack Application Server
 
-This is an extension of the [Chirpstack Appliction Server (v4)](https://www.chirpstack.io/docs/chirpstack/changelog.html) adding [Waggle's LoRaWAN device profile templates](https://github.com/waggle-sensor/wes-lorawan-device-templates).
+This is an extension of the [Chirpstack Appliction Server (v4)](https://www.chirpstack.io/docs/chirpstack/changelog.html) adding [Waggle's LoRaWAN device profile templates](https://github.com/waggle-sensor/wes-lorawan-device-templates) and support for WireGuard VPN.
 
-This project clones our LoRaWAN device profile templates into the Chirpstack application server Docker image, allowing for the LoRaWAN device profiles to be periodically pulled and imported to chirpstack.
+## LoRaWAN Device Profile Templates
+This project clones our [LoRaWAN device profile templates](https://github.com/waggle-sensor/wes-lorawan-device-templates) via a cron job into the Chirpstack server, allowing for the LoRaWAN device profiles to be periodically pulled and imported to chirpstack.
+- The `device-templates.sh` script is used to clone and import the LoRaWAN device profile templates into the Chirpstack server.
+- The cron job is scheduled to run every hour.
+
+## WireGuard VPN Integration
+Our project also includes a WireGuard VPN connection to [waggle-auth-app](https://github.com/waggle-sensor/waggle-auth-app), which is required for our Cloud infrastructure to have access to the gRPC endpoint in our Chirpstack servers sitting in our nodes.
+- The WireGuard configuration is managed through the `init-wireguard.sh` script, which handles the setup and management of the VPN connection.
+    - The WireGuard configuration is fetched from a specified endpoint, which requires authentication using a token and keyword.
+    - The required variables for the script to run include `WG_GET_CONFIG_ENDPOINT`, `AUTH_NODE_KEYWORD`, and `django-token` secret in `/mnt/token`.
+- The `check-wg0.sh` script checks if the WireGuard interface is up and has recent handshakes, ensuring a stable VPN connection.
+- The cron job is scheduled to run every 5 minutes to ensure the WireGuard connection is active.
 
 References:
 - https://www.chirpstack.io/docs/chirpstack/use/device-profile-templates.html
+- https://www.wireguard.com

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ Our project also includes a WireGuard VPN connection to [waggle-auth-app](https:
 - The `check-wg0.sh` script checks if the WireGuard interface is up and has recent handshakes, ensuring a stable VPN connection.
 - The cron job is scheduled to run every 5 minutes to ensure the WireGuard connection is active.
 
+## Versioning
+The version of the `wes-chirpstack-server` is aligned with the version of the `chirpstack/chirpstack` image, but the patch version can differ.
+
+For example, if the `chirpstack/chirpstack` image is at version 4.14, the `wes-chirpstack-server` is at version 4.14. But if a patch version is needed, the `wes-chirpstack-server` can be at version 4.14.1 even if the `chirpstack/chirpstack` image is at version 4.14.0.
+
 References:
 - https://www.chirpstack.io/docs/chirpstack/use/device-profile-templates.html
 - https://www.wireguard.com

--- a/check-wg0.sh
+++ b/check-wg0.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash -l
 
 # Check if wg0 interface exists and is up
 if ip link show wg0 > /dev/null 2>&1; then

--- a/check-wg0.sh
+++ b/check-wg0.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -l
+set -euo pipefail
 
 # Check if wg0 interface exists and is up
 if ip link show wg0 > /dev/null 2>&1; then
@@ -8,10 +9,16 @@ else
     exit 1
 fi
 
-# Check for peers with recent handshake (within last 5 minutes = 300 seconds)
+# Get current time
 CURRENT_TIME=$(date +%s)
-HANDSHAKES=$(wg show wg0 latest-handshakes | awk '{print $2}')
 
+# Get latest handshakes
+if ! HANDSHAKES_RAW=$(wg show wg0 latest-handshakes 2>/dev/null); then
+    echo "[WIREGUARD] Failed to get latest-handshakes from wg0"
+    exit 1
+fi
+
+HANDSHAKES=$(echo "$HANDSHAKES_RAW" | awk '{print $2}')
 HANDSHAKE_FOUND=0
 
 for hs in $HANDSHAKES; do

--- a/check-wg0.sh
+++ b/check-wg0.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+# Check if wg0 interface exists and is up
+if ip link show wg0 > /dev/null 2>&1; then
+    echo "[WIREGUARD] wg0 is up"
+else
+    echo "[WIREGUARD] wg0 does not exist or is down"
+    exit 1
+fi
+
+# Check for peers with recent handshake (within last 5 minutes = 300 seconds)
+CURRENT_TIME=$(date +%s)
+HANDSHAKES=$(wg show wg0 latest-handshakes | awk '{print $2}')
+
+HANDSHAKE_FOUND=0
+
+for hs in $HANDSHAKES; do
+    if [ "$hs" -gt 0 ]; then
+        DIFF=$((CURRENT_TIME - hs))
+        if [ "$DIFF" -lt 300 ]; then
+            HANDSHAKE_FOUND=1
+            echo "[WIREGUARD] Recent handshake detected ($DIFF seconds ago)"
+            break
+        fi
+    fi
+done
+
+if [ "$HANDSHAKE_FOUND" -eq 1 ]; then
+    echo "[WIREGUARD] wg0 has recent handshake(s)"
+    exit 0
+else
+    echo "[WIREGUARD] No recent handshakes found on wg0"
+    exit 1
+fi

--- a/device-templates.sh
+++ b/device-templates.sh
@@ -2,14 +2,14 @@
 
 # Clone or update the repository
 if [ ! -d "$TARGET_DIR" ]; then
-  echo "device-templates: Cloning repository $DEVICE_TEMPLATES_REPO to $TARGET_DIR"
+  echo "[DEVICE-TEMPLATES] Cloning repository $DEVICE_TEMPLATES_REPO to $TARGET_DIR"
   git clone "$DEVICE_TEMPLATES_REPO" -b master --single-branch "$TARGET_DIR"
 else
-  echo "device-templates: Updating repository in $TARGET_DIR"
+  echo "[DEVICE-TEMPLATES] Updating repository in $TARGET_DIR"
   cd "$TARGET_DIR"
   git pull
 fi
 
 # Run the Chirpstack command to import device templates
-echo "device-templates: Running Chirpstack import device-templates command"
+echo "[DEVICE-TEMPLATES] Running Chirpstack import device-templates command"
 chirpstack -c /etc/chirpstack-waggle import-legacy-lorawan-devices-repository -d "$TARGET_DIR"

--- a/init-wireguard.sh
+++ b/init-wireguard.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
-ENDPOINT=http://localhost:8005/node-auth/wireguard/
+
+# Check if WG_GET_CONFIG_ENDPOINT is set
+if [ -z "$WG_GET_CONFIG_ENDPOINT" ]; then
+    echo "[WIREGUARD] WG_GET_CONFIG_ENDPOINT not set, exiting. Please set this environment variable to the endpoint to get the WireGuard config."
+    exit 0
+fi
 
 # Check if wg0 is up
 if /usr/local/bin/check-wg0.sh; then

--- a/init-wireguard.sh
+++ b/init-wireguard.sh
@@ -93,6 +93,7 @@ ip link set up dev $IFACE
 
 # Apply the config
 wg setconf $IFACE $WG_CONFIG
+ip route add $SERVER_WG_IP/32 dev $IFACE
 
 # Set up routing (container-only). TODO: Check if wg0 shows up outside the container
 # ip route del default

--- a/init-wireguard.sh
+++ b/init-wireguard.sh
@@ -68,6 +68,7 @@ Endpoint = $SERVER_PUB_IP:$SERVER_PORT
 AllowedIPs = $SERVER_WG_IP/32
 PersistentKeepalive = 25
 EOF
+chmod 600 $WG_CONFIG
 
 # Start WireGuard
 echo "[WIREGUARD] Starting WireGuard with $WG_CONFIG ..."

--- a/init-wireguard.sh
+++ b/init-wireguard.sh
@@ -12,9 +12,12 @@ if [ -z "$AUTH_NODE_KEYWORD" ]; then
     exit 0
 fi
 
-# Check if wg0 is up
+# Check if wg0 is up and healthy
 if /usr/local/bin/check-wg0.sh; then
     exit 0
+else
+    echo "[WIREGUARD] wg0 not up or stale handshake."
+    ip link del wg0 2>/dev/null || true
 fi
 
 # Check for token
@@ -61,7 +64,6 @@ echo "[WIREGUARD] Writing WireGuard config to $WG_CONFIG ..."
 cat <<EOF > $WG_CONFIG
 [Interface]
 PrivateKey = $NODE_PRIV_KEY
-Address = $NODE_WG_IP
 
 [Peer]
 PublicKey = $SERVER_PUB_KEY
@@ -72,17 +74,22 @@ EOF
 chmod 600 $WG_CONFIG
 
 # Start WireGuard in user space
-echo "[WIREGUARD] Starting WireGuard-go with $WG_CONFIG ..."
+echo "[WIREGUARD] Starting wireguard-go on interface $IFACE ..."
 wireguard-go $IFACE &
 WG_PID=$!
 sleep 10
 
-# Check wg0 interface created
-if ! ip link show wg0 > /dev/null 2>&1; then
-    echo "[WIREGUARD] Interface wg0 not found. Killing wireguard-go. Exiting."
+# Check if interface created
+if ! ip link show $IFACE > /dev/null 2>&1; then
+    echo "[WIREGUARD] Interface $IFACE not found. Killing wireguard-go. Exiting."
     kill $WG_PID
     exit 1
 fi
+
+# Assign IP
+echo "[WIREGUARD] Assigning IP $NODE_WG_IP to $IFACE ..."
+ip address add $NODE_WG_IP dev $IFACE
+ip link set up dev $IFACE
 
 # Apply the config
 wg setconf $IFACE $WG_CONFIG

--- a/init-wireguard.sh
+++ b/init-wireguard.sh
@@ -32,6 +32,7 @@ NODE_WG_IP=$(echo $JSON | jq -r '.[0].node_wg_ip')
 SERVER_PUB_KEY=$(echo $JSON | jq -r '.[0].server_pub_key')
 SERVER_PUB_IP=$(echo $JSON | jq -r '.[0].server_pub_ip')
 SERVER_PORT=$(echo $JSON | jq -r '.[0].server_wg_port')
+SERVER_WG_IP=$(echo $JSON | jq -r '.[0].server_wg_ip')
 
 # Write wg0.conf
 cat <<EOF > /wireguard/config/wg0.conf
@@ -42,7 +43,7 @@ Address = $NODE_WG_IP
 [Peer]
 PublicKey = $SERVER_PUB_KEY
 Endpoint = $SERVER_PUB_IP:$SERVER_PORT
-AllowedIPs = 0.0.0.0/0
+AllowedIPs = $SERVER_WG_IP/32
 PersistentKeepalive = 25
 EOF
 

--- a/init-wireguard.sh
+++ b/init-wireguard.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+ENDPOINT=http://localhost:8005/node-auth/wireguard/
+
+# Check if wg0 is up
+if /usr/local/bin/check-wg0.sh; then
+    exit 0
+fi
+
+# Check for token
+echo "[WIREGUARD] Looking for django token..."
+if [ ! -f /mnt/token/token ]; then
+    echo "[WIREGUARD] Token not found, exiting"
+    exit 0
+else
+    NODE_TOKEN=$(cat /mnt/token/token)
+    echo "[WIREGUARD] Token found!"
+fi
+
+# Fetch WireGuard config
+echo "[WIREGUARD] Fetching WireGuard config..."
+JSON=$(curl -s -H "Authorization: node_auth $NODE_TOKEN" $ENDPOINT)
+echo "[WIREGUARD] Parsing config and writing wg0.conf..."
+mkdir -p /wireguard/config
+NODE_PUB_KEY=$(echo $JSON | jq -r '.[0].node_wg_pub_key')
+NODE_PRIV_KEY=$(echo $JSON | jq -r '.[0].node_wg_priv_key')
+NODE_WG_IP=$(echo $JSON | jq -r '.[0].node_wg_ip')
+SERVER_PUB_KEY=$(echo $JSON | jq -r '.[0].server_pub_key')
+SERVER_PUB_IP=$(echo $JSON | jq -r '.[0].server_pub_ip')
+SERVER_PORT=$(echo $JSON | jq -r '.[0].server_wg_port')
+
+# Write wg0.conf
+cat <<EOF > /wireguard/config/wg0.conf
+[Interface]
+PrivateKey = $NODE_PRIV_KEY
+Address = $NODE_WG_IP
+
+[Peer]
+PublicKey = $SERVER_PUB_KEY
+Endpoint = $SERVER_PUB_IP:$SERVER_PORT
+AllowedIPs = 0.0.0.0/0
+PersistentKeepalive = 25
+EOF
+
+# Start WireGuard
+echo "[WIREGUARD] WireGuard config written to /wireguard/config/wg0.conf"
+echo "[WIREGUARD] Starting WireGuard..."
+wg-quick up /wireguard/config/wg0.conf
+echo "[WIREGUARD] WireGuard started!"

--- a/init-wireguard.sh
+++ b/init-wireguard.sh
@@ -29,8 +29,10 @@ fi
 
 # Fetch WireGuard config
 echo "[WIREGUARD] Fetching WireGuard config from $WG_GET_CONFIG_ENDPOINT ..."
-JSON=$(curl -s -f -H "Authorization: $AUTH_NODE_KEYWORD $NODE_TOKEN" "$WG_GET_CONFIG_ENDPOINT")
-if [ $? -ne 0 ] || [ -z "$JSON" ]; then
+JSON=$(wget --quiet --header="Authorization: $AUTH_NODE_KEYWORD $NODE_TOKEN" \
+             "$WG_GET_CONFIG_ENDPOINT" -O -)
+
+if [ -z "$JSON" ]; then
     echo "[WIREGUARD] Failed to fetch WireGuard config or empty response. Exiting."
     exit 1
 fi

--- a/init-wireguard.sh
+++ b/init-wireguard.sh
@@ -2,7 +2,13 @@
 
 # Check if WG_GET_CONFIG_ENDPOINT is set
 if [ -z "$WG_GET_CONFIG_ENDPOINT" ]; then
-    echo "[WIREGUARD] WG_GET_CONFIG_ENDPOINT not set, exiting. Please set this environment variable to the endpoint to get the WireGuard config."
+    echo "[WIREGUARD] WG_GET_CONFIG_ENDPOINT not set, exiting. Please set this environment variable to the GET WireGuard config endpoint."
+    exit 0
+fi
+
+# check if AUTH_NODE_KEYWORD is set
+if [ -z "$AUTH_NODE_KEYWORD" ]; then
+    echo "[WIREGUARD] AUTH_NODE_KEYWORD not set, exiting. Please set this environment variable to the authorization keyword for the GET WireGuard config endpoint."
     exit 0
 fi
 
@@ -22,20 +28,34 @@ else
 fi
 
 # Fetch WireGuard config
-echo "[WIREGUARD] Fetching WireGuard config..."
-JSON=$(curl -s -H "Authorization: node_auth $NODE_TOKEN" $ENDPOINT)
-echo "[WIREGUARD] Parsing config and writing wg0.conf..."
-mkdir -p /wireguard/config
-NODE_PUB_KEY=$(echo $JSON | jq -r '.[0].node_wg_pub_key')
-NODE_PRIV_KEY=$(echo $JSON | jq -r '.[0].node_wg_priv_key')
-NODE_WG_IP=$(echo $JSON | jq -r '.[0].node_wg_ip')
-SERVER_PUB_KEY=$(echo $JSON | jq -r '.[0].server_pub_key')
-SERVER_PUB_IP=$(echo $JSON | jq -r '.[0].server_pub_ip')
-SERVER_PORT=$(echo $JSON | jq -r '.[0].server_wg_port')
-SERVER_WG_IP=$(echo $JSON | jq -r '.[0].server_wg_ip')
+echo "[WIREGUARD] Fetching WireGuard config from $WG_GET_CONFIG_ENDPOINT ..."
+JSON=$(curl -s -f -H "Authorization: $AUTH_NODE_KEYWORD $NODE_TOKEN" "$WG_GET_CONFIG_ENDPOINT")
+if [ $? -ne 0 ] || [ -z "$JSON" ]; then
+    echo "[WIREGUARD] Failed to fetch WireGuard config or empty response. Exiting."
+    exit 1
+fi
+
+# Parse and validate config fields
+echo "[WIREGUARD] Parsing config..."
+NODE_PUB_KEY=$(echo "$JSON" | jq -r '.[0].node_wg_pub_key')
+NODE_PRIV_KEY=$(echo "$JSON" | jq -r '.[0].node_wg_priv_key')
+NODE_WG_IP=$(echo "$JSON" | jq -r '.[0].node_wg_ip')
+SERVER_PUB_KEY=$(echo "$JSON" | jq -r '.[0].server_pub_key')
+SERVER_PUB_IP=$(echo "$JSON" | jq -r '.[0].server_pub_ip')
+SERVER_PORT=$(echo "$JSON" | jq -r '.[0].server_wg_port')
+SERVER_WG_IP=$(echo "$JSON" | jq -r '.[0].server_wg_ip')
+
+# Validate required values
+if [ -z "$NODE_PRIV_KEY" ] || [ -z "$NODE_WG_IP" ] || [ -z "$SERVER_PUB_KEY" ] || [ -z "$SERVER_PUB_IP" ] || [ -z "$SERVER_PORT" ] || [ -z "$SERVER_WG_IP" ]; then
+    echo "[WIREGUARD] One or more required fields are missing in the config. Exiting."
+    exit 1
+fi
 
 # Write wg0.conf
-cat <<EOF > /wireguard/config/wg0.conf
+mkdir -p /wireguard/config
+WG_CONFIG="/wireguard/config/wg0.conf"
+echo "[WIREGUARD] Writing WireGuard config to $WG_CONFIG ..."
+cat <<EOF > $WG_CONFIG
 [Interface]
 PrivateKey = $NODE_PRIV_KEY
 Address = $NODE_WG_IP
@@ -48,7 +68,10 @@ PersistentKeepalive = 25
 EOF
 
 # Start WireGuard
-echo "[WIREGUARD] WireGuard config written to /wireguard/config/wg0.conf"
-echo "[WIREGUARD] Starting WireGuard..."
-wg-quick up /wireguard/config/wg0.conf
-echo "[WIREGUARD] WireGuard started!"
+echo "[WIREGUARD] Starting WireGuard with $WG_CONFIG ..."
+wg-quick up $WG_CONFIG
+if [ $? -ne 0 ]; then
+    echo "[WIREGUARD] Failed to bring up WireGuard interface wg0. Exiting."
+    exit 1
+fi
+echo "[WIREGUARD] WireGuard started successfully!"

--- a/init-wireguard.sh
+++ b/init-wireguard.sh
@@ -69,12 +69,26 @@ Endpoint = $SERVER_PUB_IP:$SERVER_PORT
 AllowedIPs = $SERVER_WG_IP/32
 PersistentKeepalive = 25
 EOF
+chmod 600 $WG_CONFIG
 
-# Start WireGuard
-echo "[WIREGUARD] Starting WireGuard with $WG_CONFIG ..."
-wg-quick up $WG_CONFIG
-if [ $? -ne 0 ]; then
-    echo "[WIREGUARD] Failed to bring up WireGuard interface $IFACE. Exiting."
+# Start WireGuard in user space
+echo "[WIREGUARD] Starting WireGuard-go with $WG_CONFIG ..."
+wireguard-go $IFACE &
+WG_PID=$!
+sleep 10
+
+# Check wg0 interface created
+if ! ip link show wg0 > /dev/null 2>&1; then
+    echo "[WIREGUARD] Interface wg0 not found. Killing wireguard-go. Exiting."
+    kill $WG_PID
     exit 1
 fi
-echo "[WIREGUARD] WireGuard started successfully!"
+
+# Apply the config
+wg setconf $IFACE $WG_CONFIG
+
+# Set up routing (container-only). TODO: Check if wg0 shows up outside the container
+# ip route del default
+# ip route add default dev $IFACE
+
+echo "[WIREGUARD] WireGuard-go started successfully!"

--- a/init-wireguard.sh
+++ b/init-wireguard.sh
@@ -53,9 +53,10 @@ if [ -z "$NODE_PRIV_KEY" ] || [ -z "$NODE_WG_IP" ] || [ -z "$SERVER_PUB_KEY" ] |
     exit 1
 fi
 
-# Write wg0.conf
+# Write config to file
 mkdir -p /wireguard/config
-WG_CONFIG="/wireguard/config/wg0.conf"
+IFACE=wg0
+WG_CONFIG="/wireguard/config/$IFACE.conf"
 echo "[WIREGUARD] Writing WireGuard config to $WG_CONFIG ..."
 cat <<EOF > $WG_CONFIG
 [Interface]
@@ -72,9 +73,15 @@ chmod 600 $WG_CONFIG
 
 # Start WireGuard
 echo "[WIREGUARD] Starting WireGuard with $WG_CONFIG ..."
-wg-quick up $WG_CONFIG
+# wg-quick up $WG_CONFIG
+ip link add dev $IFACE type wireguard
+ip address add dev $IFACE $NODE_WG_IP/30
+wg set $IFACE private-key $NODE_PRIV_KEY
+wg set $IFACE listen-port $SERVER_PORT
+ip link set up dev $IFACE
+wg set $IFACE peer $SERVER_PUB_KEY endpoint $SERVER_PUB_IP:$SERVER_PORT allowed-ips $SERVER_WG_IP/32 persistent-keepalive 25
 if [ $? -ne 0 ]; then
-    echo "[WIREGUARD] Failed to bring up WireGuard interface wg0. Exiting."
+    echo "[WIREGUARD] Failed to bring up WireGuard interface $IFACE. Exiting."
     exit 1
 fi
 echo "[WIREGUARD] WireGuard started successfully!"

--- a/init-wireguard.sh
+++ b/init-wireguard.sh
@@ -69,7 +69,6 @@ Endpoint = $SERVER_PUB_IP:$SERVER_PORT
 AllowedIPs = $SERVER_WG_IP/32
 PersistentKeepalive = 25
 EOF
-chmod 600 $WG_CONFIG
 
 # Start WireGuard
 echo "[WIREGUARD] Starting WireGuard with $WG_CONFIG ..."

--- a/init-wireguard.sh
+++ b/init-wireguard.sh
@@ -73,13 +73,7 @@ chmod 600 $WG_CONFIG
 
 # Start WireGuard
 echo "[WIREGUARD] Starting WireGuard with $WG_CONFIG ..."
-# wg-quick up $WG_CONFIG
-ip link add dev $IFACE type wireguard
-ip address add dev $IFACE $NODE_WG_IP/30
-wg set $IFACE private-key $NODE_PRIV_KEY
-wg set $IFACE listen-port $SERVER_PORT
-ip link set up dev $IFACE
-wg set $IFACE peer $SERVER_PUB_KEY endpoint $SERVER_PUB_IP:$SERVER_PORT allowed-ips $SERVER_WG_IP/32 persistent-keepalive 25
+wg-quick up $WG_CONFIG
 if [ $? -ne 0 ]; then
     echo "[WIREGUARD] Failed to bring up WireGuard interface $IFACE. Exiting."
     exit 1

--- a/init-wireguard.sh
+++ b/init-wireguard.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash -l
 
 # Check if WG_GET_CONFIG_ENDPOINT is set
 if [ -z "$WG_GET_CONFIG_ENDPOINT" ]; then


### PR DESCRIPTION
This pull request introduces WireGuard support to the project by adding new scripts, updating the Dockerfile, and enhancing existing functionality. The changes focus on integrating WireGuard configuration and monitoring, improving the logging format, and setting up periodic tasks for WireGuard initialization.

### WireGuard Integration:
* **Added WireGuard tools and scripts**: Updated the `Dockerfile` to include `wireguard-tools`, `curl`, and `jq`. Added new scripts `init-wireguard.sh` and `check-wg0.sh` for WireGuard initialization and monitoring. (`Dockerfile` [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L11-R19) `init-wireguard.sh` [[2]](diffhunk://#diff-311e7ed6f019de76f042d99c6a7a4e8ea52622a76b4d39bfb7bdf34adf10bb6fR1-R48) `check-wg0.sh` [[3]](diffhunk://#diff-4653dce155f788fdc4f1db470c3072270ca2553108d4d1ce32c1e096b23e9051R1-R34)
* **Scheduled periodic WireGuard initialization**: Updated the crontab to run `init-wireguard.sh` every 5 minutes. (`Dockerfile` [DockerfileL27-R30](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L27-R30))

### Logging Improvements:
* **Enhanced logging format**: Updated `device-templates.sh` to use a consistent and descriptive log prefix (`[DEVICE-TEMPLATES]`). (`device-templates.sh` [device-templates.shL5-R14](diffhunk://#diff-24669d52b488e23d32c4bee22e7c84dc0ab0a2744ca15aaf5586358248bd9cdbL5-R14))

### New Functionality:
* **WireGuard health check (`check-wg0.sh`)**: Added a script to verify if the `wg0` interface is up and has recent handshakes. Exits with appropriate status codes based on the check results. (`check-wg0.sh` [check-wg0.shR1-R34](diffhunk://#diff-4653dce155f788fdc4f1db470c3072270ca2553108d4d1ce32c1e096b23e9051R1-R34))
* **WireGuard initialization (`init-wireguard.sh`)**: Added a script to fetch WireGuard configuration from a remote endpoint, generate the `wg0.conf` file, and start WireGuard. It ensures the presence of a valid token and handles configuration parsing. (`init-wireguard.sh` [init-wireguard.shR1-R48](diffhunk://#diff-311e7ed6f019de76f042d99c6a7a4e8ea52622a76b4d39bfb7bdf34adf10bb6fR1-R48))